### PR TITLE
Update markdown parser to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: White Paper
-markdown: redcarpet
+markdown: kramdown
 url: http://vimsheet.com
 description: A Great Vim Cheat Sheet
 


### PR DESCRIPTION
To quote the email I received from upon deploying this project:

> You are currently using the 'redcarpet' Markdown engine, which is no longer supported by GitHub Pages and may cease working at any time. To ensure your site continues to build, remove the 'markdown' setting in your site's '_config.yml' file and confirm your site renders as expected. For more information, see https://help.github.com/articles/updating-your-markdown-processor-to-kramdown/.
> For information on troubleshooting Jekyll see:
> https://help.github.com/articles/troubleshooting-jekyll-builds