### PR TITLE
Generalized font URI to support HTTPS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/base.css" type="text/css" />
 <link rel="stylesheet" href="css/github.min.css" type="text/css" />
 <link rel="stylesheet" href="css/octicons.css" type="text/css" />
-<link href='http://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
I generalized the Google fonts URI so that Lato will work properly regardless of whether the page is served via HTTP or HTTPS. If someone forks this repo and hosts it on their own GitHub Pages, it will be https by default (e.g. https://nreilingh.github.io/vimsheet/)